### PR TITLE
added support for generic and custom data types

### DIFF
--- a/src/main/java/com/bigchaindb/builders/BigchainDbTransactionBuilder.java
+++ b/src/main/java/com/bigchaindb/builders/BigchainDbTransactionBuilder.java
@@ -31,6 +31,7 @@ import com.bigchaindb.model.Details;
 import com.bigchaindb.model.FulFill;
 import com.bigchaindb.model.GenericCallback;
 import com.bigchaindb.model.Input;
+import com.bigchaindb.model.MetaData;
 import com.bigchaindb.model.Output;
 import com.bigchaindb.model.Transaction;
 import com.bigchaindb.util.DriverUtils;
@@ -110,7 +111,7 @@ public class BigchainDbTransactionBuilder {
          * Adds the assets.
          *
          * @param assets the assets
-         * @param assetsDataClass class if asset data
+         * @param assetsDataClass class of asset data
          * @return the i asset meta data
          */
         ITransactionAttributes addAssets(Object assets, Class assetsDataClass);
@@ -119,9 +120,10 @@ public class BigchainDbTransactionBuilder {
          * Adds the meta data.
          *
          * @param metaData the json object
+         * @param metaDataClass class of meta data
          * @return the i asset meta data
          */
-        ITransactionAttributes addMetaData(Object metaData);
+        ITransactionAttributes addMetaData(Object metaData, Class metaDataClass);
 
         /**
          * Add the class and deserializer for metadata
@@ -214,6 +216,7 @@ public class BigchainDbTransactionBuilder {
          * The metadata.
          */
         private Object metadata = null;
+        private Class metadataClass = null;
 
         /**
          * The assets.
@@ -332,8 +335,9 @@ public class BigchainDbTransactionBuilder {
             return this;
         }
 
-        public ITransactionAttributes addMetaData(Object object) {
+        public ITransactionAttributes addMetaData(Object object, Class metaDataClass) {
             this.metadata = object;
+            this.metadataClass = metaDataClass;
             return this;
         }
 
@@ -378,7 +382,7 @@ public class BigchainDbTransactionBuilder {
                 // otherwise it's an asset
                 this.transaction.setAsset(new Asset(this.assets, this.assetsDataClass));
             }
-            this.transaction.setMetaData(this.metadata);
+            this.transaction.setMetaData(new MetaData(this.metadata, this.metadataClass));
             this.transaction.setVersion("2.0");
 
             this.transaction.setId(null);

--- a/src/main/java/com/bigchaindb/json/strategy/MetaDataSerializer.java
+++ b/src/main/java/com/bigchaindb/json/strategy/MetaDataSerializer.java
@@ -25,7 +25,7 @@ public class MetaDataSerializer implements JsonSerializer<MetaData>
 	public JsonElement serialize( MetaData src, Type typeOfSrc, JsonSerializationContext context )
 	{
 		Gson gson = JsonUtils.getGson();
-		JsonElement metadata = gson.toJsonTree( src.getMetadata(), new TypeToken<Map<String, String>>() { }.getType() );
+		JsonElement metadata = gson.toJsonTree( src.getMetaData(), src.getDataClass() );//new TypeToken<Map<String, String>>() { }.getType() );
 		return metadata;
 	}
 }

--- a/src/main/java/com/bigchaindb/json/strategy/TransactionDeserializer.java
+++ b/src/main/java/com/bigchaindb/json/strategy/TransactionDeserializer.java
@@ -6,6 +6,7 @@
 package com.bigchaindb.json.strategy;
 
 import com.bigchaindb.model.Asset;
+import com.bigchaindb.model.MetaData;
 import com.bigchaindb.model.Input;
 import com.bigchaindb.model.Output;
 import com.bigchaindb.model.Transaction;
@@ -48,7 +49,7 @@ public class TransactionDeserializer implements JsonDeserializer<Transaction> {
 		JsonElement jElement = json.getAsJsonObject();
 
 		transaction.setAsset( JsonUtils.fromJson(jElement.getAsJsonObject().get("asset").toString(), Asset.class));
-		transaction.setMetaData( JsonUtils.fromJson( jElement.getAsJsonObject().get("metadata").toString(), metaDataClass ));
+		transaction.setMetaData( JsonUtils.fromJson(jElement.getAsJsonObject().get("metadata").toString(), metaDataClass));
 		transaction.setId(jElement.getAsJsonObject().get("id").toString().replace("\"", ""));
 
 		for( JsonElement jInputElement: jElement.getAsJsonObject().get("inputs").getAsJsonArray() ) {

--- a/src/main/java/com/bigchaindb/model/MetaData.java
+++ b/src/main/java/com/bigchaindb/model/MetaData.java
@@ -5,26 +5,78 @@
  */
 package com.bigchaindb.model;
 
+import com.bigchaindb.annotations.Exclude;
 import com.google.gson.annotations.SerializedName;
 
-import java.util.Map;
-import java.util.TreeMap;
+import java.io.Serializable;
 
-
-
-/**
+/*
  * The Class MetaData.
  */
-public class MetaData {
+public class MetaData implements Serializable {
 	
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
 	/** The id. */
 	@SerializedName("id")
+	@Exclude
 	private String id;
 	
-	/** The metadata. */
-	@SerializedName("metadata")
-	private Map<String,String> metadata = new TreeMap<String, String>();
+	/** The data. */
+	@SerializedName("data")
+	private Object data;
+
+	/** the data class the type of the data class needed for serialization/deserialization */
+	@Exclude
+	private Class dataClass = com.google.gson.internal.LinkedTreeMap.class;
+
+	/**
+	 * Instantiates a new metadata.
+	 */
+	public MetaData() {}
 	
+	/**
+	 * Instantiates a new metadata.
+	 *
+	 * @param data the data
+	 * @param dataClass due to type erasure the data class needs to be provided for serialization/deserialization
+	 */
+	public MetaData(Object data, Class dataClass) {
+		this.data = data;
+		this.dataClass = dataClass;
+	}
+
+	/**
+	 * Instantiates a new metadata by reference.
+	 *
+	 * @param id ID of the metadata.
+	 */
+	public MetaData(String id) {
+		this.id = id;
+	}
+	
+	/**
+	 * Gets the data.
+	 *
+	 * @return the data
+	 */
+	public Object getMetaData() {
+		return data;
+	}
+
+	/**
+	 * return the type of the Asset data class
+	 *
+	 * @return  the data class type
+	 */
+	public Class getDataClass()
+	{
+		return dataClass;
+	}
+
 	/**
 	 * Gets the id.
 	 *
@@ -32,27 +84,5 @@ public class MetaData {
 	 */
 	public String getId() {
 		return id;
-	}
-
-	/**
-	 * Sets the id.
-	 *
-	 * @param id the new id
-	 */
-	public void setId(String id) {
-		this.id = id;
-	}
-
-	/**
-	 * Gets the metadata.
-	 *
-	 * @return the metadata
-	 */
-	public Map<String, String> getMetadata() {
-		return metadata;
-	}
-
-	public void setMetaData(String key, String value) {
-		this.metadata.put(key, value);
 	}
 }

--- a/src/main/java/com/bigchaindb/model/Transaction.java
+++ b/src/main/java/com/bigchaindb/model/Transaction.java
@@ -126,11 +126,11 @@ public class Transaction implements Serializable {
 	/**
 	 * Set the metaData object
 	 *
-	 * @param obj the metadata object
+	 * @param metadata the metadata object
 	 */
-	public void setMetaData( Object obj )
+	public void setMetaData( Object metadata )
 	{
-		this.metaData = obj;
+		this.metaData = metadata;
 	}
 
 	/**


### PR DESCRIPTION
This PR provides support for generic and custom data types in Asset data and Meta data
(e.g.) Map<String, CustomClass> 
. But, this PR doesn't support complex nested data types (e.g) Map<String, Map<String, CustomClass>>. It will need another PR