### PR TITLE
Issue #24 Handle NPE When Transaction Not Present

### DIFF
--- a/src/main/java/com/bigchaindb/api/TransactionsApi.java
+++ b/src/main/java/com/bigchaindb/api/TransactionsApi.java
@@ -7,6 +7,7 @@ package com.bigchaindb.api;
 
 import com.bigchaindb.constants.BigchainDbApi;
 import com.bigchaindb.constants.Operations;
+import com.bigchaindb.exceptions.TransactionNotFoundException;
 import com.bigchaindb.model.BigChainDBGlobals;
 import com.bigchaindb.model.GenericCallback;
 import com.bigchaindb.model.Transaction;
@@ -16,6 +17,7 @@ import com.bigchaindb.util.NetworkUtils;
 
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,9 +68,14 @@ public class TransactionsApi extends AbstractApi {
 	 * @throws IOException
 	 *             Signals that an I/O exception has occurred.
 	 */
-	public static Transaction getTransactionById(String id) throws IOException {
+	public static Transaction getTransactionById(String id)
+			throws IOException, TransactionNotFoundException {
 		log.debug( "getTransactionById Call :" + id );
 		Response response = NetworkUtils.sendGetRequest(BigChainDBGlobals.getBaseUrl() + BigchainDbApi.TRANSACTIONS + "/" + id);
+		if(!response.isSuccessful()){
+			if(response.code() == HttpStatus.SC_NOT_FOUND)
+				throw new TransactionNotFoundException("Transaction with id " + id + " not present");
+		}
 		String body = response.body().string();
 		response.close();
 		return JsonUtils.fromJson(body, Transaction.class);

--- a/src/main/java/com/bigchaindb/exceptions/TransactionNotFoundException.java
+++ b/src/main/java/com/bigchaindb/exceptions/TransactionNotFoundException.java
@@ -1,0 +1,8 @@
+package com.bigchaindb.exceptions;
+
+public class TransactionNotFoundException extends Exception {
+
+  public TransactionNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/src/test/java/com/bigchaindb/api/TransactionCreateApiTest.java
+++ b/src/test/java/com/bigchaindb/api/TransactionCreateApiTest.java
@@ -8,6 +8,7 @@ package com.bigchaindb.api;
 import com.bigchaindb.api.TransactionsApi;
 import com.bigchaindb.builders.BigchainDbTransactionBuilder;
 import com.bigchaindb.constants.Operations;
+import com.bigchaindb.exceptions.TransactionNotFoundException;
 import com.bigchaindb.json.strategy.MetaDataDeserializer;
 import com.bigchaindb.json.strategy.MetaDataSerializer;
 import com.bigchaindb.json.strategy.TransactionDeserializer;
@@ -41,6 +42,7 @@ import static org.junit.Assert.assertTrue;
 public class TransactionCreateApiTest extends AbstractApiTest {
 
     public static String TRANSACTION_ID = "4957744b3ac54434b8270f2c854cc1040228c82ea4e72d66d2887a4d3e30b317";
+    public static String NON_EXISTENT_TRANSACTION_ID = "4957744b3ac5434b8270f2c854cc1040228c8ea4e72d66d2887a4d3e30b317";
     public static String V1_GET_TRANSACTION_JSON = "{\n" +
             "  \"asset\": {\n" +
             "    \"data\": {\n" +
@@ -245,8 +247,24 @@ public class TransactionCreateApiTest extends AbstractApiTest {
             assertTrue(transaction.getId().equals(TRANSACTION_ID));
         } catch (IOException e) {
             e.printStackTrace();
+        } catch (TransactionNotFoundException e) {
+            e.printStackTrace();
         }
     }
+
+    /**
+     * Test get transaction when the transaction with supplied id is not present.
+     */
+    @Test(expected = TransactionNotFoundException.class)
+    public void testGetNonExistentTransaction() throws TransactionNotFoundException {
+        try {
+           TransactionsApi.getTransactionById(NON_EXISTENT_TRANSACTION_ID);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+
 
     /**
      * Test get transactions by assets id


### PR DESCRIPTION
This PR adds code to prevent the NullPointerException when a transaction with a particular ID is requested, but isn't present in BigchainDB.

Added a new exception **TransactionNotFoundException** which thrown from the method **TransactionApi::getTransactionById**. 

First check if the response(OkHttp library) is successful or not. If not successful we check the http status code for 404(NOT_FOUND), and then throw this exception. Added the specific check for 404 as there needs to be a distinction b/w different other errors and 404 so that it is not confusing for the user. 

 The HttpStatus interface is part of org.apache.http. Since OkHttp does not define any constants of it's own and rather suggests [https://github.com/square/retrofit/issues/2638](url) to just use the isSuccessful method or raw integer values.